### PR TITLE
create -> created for SlackFile json format

### DIFF
--- a/src/main/scala/slack/models/SlackFile.scala
+++ b/src/main/scala/slack/models/SlackFile.scala
@@ -3,7 +3,7 @@ package slack.models
 // TODO: 22 field limit :(
 case class SlackFile (
   id: String,
-  create: Long,
+  created: Long,
   timestamp: Long,
   name: Option[String],
   title: String,


### PR DESCRIPTION
Hey Bryan,

I found that my app using your library crashes on file attachments. Investigating this, I found that format for files contains 'created' instead of 'create'. I'm not sure if it was a typo in your code or if it _used to_ work like that in Slack before, but now it is definitely `created'.

Example attachments json (in log message):

```
[INFO] [06/20/2015 15:37:58.915] [Baka-akka.actor.default-dispatcher-13] [akka://Baka/user/$a/$a] [WebSocketClient] Received Text Frame: {"type":"file_public","file":{"id":"F06KA3A7L","created":1434814676,"timestamp":1434814676,"name":"Screenshot_24.png","title":"Screenshot_24.png","mimetype":"image/png","filetype":"png","pretty_type":"PNG","user":"U04NY8SRD","editable":false,"size":50523,"mode":"hosted","is_external":false,"external_type":"","is_public":true,"public_url_shared":false,"url":"https://slack-files.com/files-pub/T04G68VQ8-F06KA3A7L-740db432d9/screenshot_24.png","url_download":"https://slack-files.com/files-pub/T04G68VQ8-F06KA3A7L-740db432d9/download/screenshot_24.png","url_private":"https://files.slack.com/files-pri/T04G68VQ8-F06KA3A7L/screenshot_24.png","url_private_download":"https://files.slack.com/files-pri/T04G68VQ8-F06KA3A7L/download/screenshot_24.png","thumb_64":"https://slack-files.com/files-tmb/T04G68VQ8-F06KA3A7L-4d217c78c7/screenshot_24_64.png","thumb_80":"https://slack-files.com/files-tmb/T04G68VQ8-F06KA3A7L-4d217c78c7/screenshot_24_80.png","thumb_360":"https://slack-files.com/files-tmb/T04G68VQ8-F06KA3A7L-4d217c78c7/screenshot_24_360.png","thumb_360_w":193,"thumb_360_h":360,"thumb_480":"https://slack-files.com/files-tmb/T04G68VQ8-F06KA3A7L-4d217c78c7/screenshot_24_480.png","thumb_480_w":257,"thumb_480_h":480,"thumb_160":"https://slack-files.com/files-tmb/T04G68VQ8-F06KA3A7L-4d217c78c7/screenshot_24_160.png","image_exif_rotation":1,"permalink":"https://odeskconf.slack.com/files/letalumil/F06KA3A7L/screenshot_24.png","permalink_public":"https://slack-files.com/T04G68VQ8-F06KA3A7L-740db432d9","channels":["C04G68W0C"],"groups":[],"ims":[],"comments_count":0},"event_ts":"1434814678.065649"}
```