### PR TITLE
Allow passing a timeout into SlackRtmClient

### DIFF
--- a/src/main/scala/slack/Main.scala
+++ b/src/main/scala/slack/Main.scala
@@ -1,21 +1,22 @@
 package slack
 
-import slack.api.SlackApiClient
-import slack.rtm.SlackRtmClient
 import akka.actor._
+import slack.rtm.SlackRtmClient
+
+import scala.concurrent.duration._
 
 object Main extends App {
   val token = "..."
   implicit val system = ActorSystem("slack")
   implicit val ec = system.dispatcher
 
-  val client = SlackRtmClient(token)
+  val client = SlackRtmClient(token, 5.seconds)
   val selfId = client.state.self.id
 
   client.onMessage { message =>
     val mentionedIds = SlackUtil.extractMentionedIds(message.text)
 
-    if(mentionedIds.contains(selfId)) {
+    if (mentionedIds.contains(selfId)) {
       client.sendMessage(message.channel, s"<@${message.user}>: Hey!")
     }
   }

--- a/src/main/scala/slack/rtm/SlackRtmClient.scala
+++ b/src/main/scala/slack/rtm/SlackRtmClient.scala
@@ -18,16 +18,16 @@ import WebSocketClientActor._
 import SlackRtmConnectionActor._
 
 object SlackRtmClient {
-  def apply(token: String)(implicit arf: ActorRefFactory): SlackRtmClient = {
-    new SlackRtmClient(token)
+  def apply(token: String, duration: FiniteDuration)(implicit arf: ActorRefFactory): SlackRtmClient = {
+    new SlackRtmClient(token, duration)
   }
 }
 
-class SlackRtmClient(token: String)(implicit arf: ActorRefFactory) {
-  implicit val timeout = new Timeout(5.second)
+class SlackRtmClient(token: String, duration: FiniteDuration)(implicit arf: ActorRefFactory) {
+  implicit val timeout = new Timeout(duration)
   implicit val ec = arf.dispatcher
 
-  val apiClient = BlockingSlackApiClient(token)
+  val apiClient = BlockingSlackApiClient(token, duration)
   val state = RtmState(apiClient.startRealTimeMessageSession())
   val actor = SlackRtmConnectionActor(token, state)
 


### PR DESCRIPTION
For users of `SlackRtmClient`, the timeout of 5 seconds is hard coded. While testing, I've found occasions where 5 seconds did not suffice to establish a connection, and consequently, there were timeouts. This change exposes the timeout in the `SlackRtmClient` constructor.