### PR TITLE
Initial Message Subtype Support

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -5,7 +5,7 @@ import sbtrelease._
 
 object BuildSettings {
   val buildOrganization = "com.github.gilbertw1"
-  val buildVersion      = "0.1.3"
+  val buildVersion      = "0.1.3-SNAPSHOT"
   val buildScalaVersion = "2.11.7"
 
   val buildSettings = Defaults.defaultSettings ++ Seq (

--- a/src/main/scala/slack/models/Events.scala
+++ b/src/main/scala/slack/models/Events.scala
@@ -18,22 +18,43 @@ case class Message (
   is_starred: Option[Boolean]
 ) extends SlackEvent
 
-case class SubMessage (
-  ts: String,
-  user: String,
-  text: String,
-  is_starred: Option[Boolean]
-) extends SlackEvent
-
 // TODO: Message Sub-types
 case class MessageWithSubtype (
-  ts: String,
-  message: Option[SubMessage],
-  subtype: String,
-  hidden: Option[Boolean],
-  event_ts: Option[String],
-  channel: String
+ ts: String,
+ channel: String,
+ user: String,
+ text: String,
+ is_starred: Option[Boolean],
+ messageSubType: MessageSubtype
 ) extends SlackEvent
+
+sealed trait MessageSubtype {
+  def subtype: String
+}
+
+object MessageSubtypes {
+
+  // Fallback for unhandled message sub-types
+  case class UnhandledSubtype(subtype: String) extends MessageSubtype
+
+  case class BotMessage(
+    bot_id: String,
+    username: Option[String]
+  ) extends MessageSubtype {
+    val subtype = "bot_message"
+  }
+
+  case class MeMessage(subtype: String) extends MessageSubtype {
+    //val subtype = "me_message"
+  }
+
+  case class ChannelNameMessage(
+    oldname: String,
+    name: String
+  ) extends MessageSubtype {
+    val subtype = "channel_name"
+  }
+}
 
 case class ReactionAdded (
   reaction: String,

--- a/src/test/scala/TestJsonMessages.scala
+++ b/src/test/scala/TestJsonMessages.scala
@@ -1,13 +1,13 @@
 import org.scalatest.FunSuite
 import play.api.libs.json.Json
-import slack.models.SlackEvent
+import slack.models.{MessageSubtypes, SlackEvent}
 
 /**
  * Created by ptx on 9/5/15.
  */
 class TestJsonMessages extends FunSuite {
 
-  test("user prencese change") {
+  test("user presence change") {
 
     val json = Json.parse( """{"type":"presence_change","user":"U0A2DCEBS","presence":"active"}""")
     val ev = json.as[SlackEvent]
@@ -94,6 +94,44 @@ class TestJsonMessages extends FunSuite {
       "type": "group_left", "channel": "G0AAYN0E7"
     }""")
     val ev = json.as[SlackEvent]
+  }
+
+  test("bot message parsed") {
+    val json = Json.parse(
+      """{
+        |  "type":"message",
+        |  "user":"U0A2DCEBS",
+        |  "channel":"G0AAYN0E7",
+        |  "text": "Huzzah!",
+        |  "subtype":"bot_message",
+        |  "bot_id":"U0A2DCEB4",
+        |  "username":"Mr. Huzzah"
+        |}""".stripMargin)
+    val ev = json.as[MessageSubtypes.BotMessage]
+  }
+
+  test("me message parsed") {
+    val json = Json.parse(
+      """{
+        |  "type":"message",
+        |  "user":"U0A2DCEBS",
+        |  "channel":"G0AAYN0E7",
+        |  "text": "Cheers!",
+        |  "subtype":"me_message"
+        |}""".stripMargin)
+    val ev = json.as[MessageSubtypes.MeMessage]
+  }
+
+  test("unhandled message parsed") {
+    val json = Json.parse(
+      """{
+        |  "type":"message",
+        |  "user":"U0A2DCEBS",
+        |  "channel":"G0AAYN0E7",
+        |  "text": "An ordinary box for pizza.",
+        |  "subtype":"pizza_box"
+        |}""".stripMargin)
+    val ev = json.as[MessageSubtypes.UnhandledSubtype]
   }
 
 }


### PR DESCRIPTION
Added initial support for messages with subtypes and basic tests for them. I think I followed the way you were intending to do it from the stubs you had in place.