### PR TITLE
Message changed event handled

### DIFF
--- a/src/main/scala/slack/models/Events.scala
+++ b/src/main/scala/slack/models/Events.scala
@@ -18,6 +18,20 @@ case class Message (
   is_starred: Option[Boolean]
 ) extends SlackEvent
 
+case class EditMessage (
+  user: String,
+  text: String,
+  ts:String
+)
+
+case class MessageChanged (
+  message: EditMessage,
+  previous_message: EditMessage,
+  ts: String,
+  event_ts: String,
+  channel: String
+) extends SlackEvent
+
 // TODO: Message Sub-types
 case class MessageWithSubtype (
  ts: String,

--- a/src/main/scala/slack/models/package.scala
+++ b/src/main/scala/slack/models/package.scala
@@ -22,6 +22,8 @@ package object models {
   // Event Formats
   implicit val helloFmt = Json.format[Hello]
   implicit val messageFmt = Json.format[Message]
+  implicit val editMessageFmt = Json.format[EditMessage]
+  implicit val messageChangedFmt = Json.format[MessageChanged]
   implicit val reactionAddedFmt= Json.format[ReactionAdded]
   implicit val reactionRemovedFmt= Json.format[ReactionRemoved]
   implicit val userTypingFmt = Json.format[UserTyping]
@@ -103,6 +105,7 @@ package object models {
       event match {
         case e: Hello => Json.toJson(e)
         case e: Message => Json.toJson(e)
+        case e: MessageChanged => Json.toJson(e)
         case e: MessageWithSubtype => Json.toJson(e)
         case e: BotMessage => Json.toJson(e)
         case e: MeMessage => Json.toJson(e)
@@ -201,6 +204,7 @@ package object models {
       if(etype.isDefined) {
         etype.get match {
           case "hello" => JsSuccess(jsValue.as[Hello])
+          case "message" if subtype.contains("message_changed") => JsSuccess(jsValue.as[MessageChanged])
           case "message" if subtype.isDefined => JsSuccess(jsValue.as[MessageWithSubtype])
           case "message" => JsSuccess(jsValue.as[Message])
           case "user_typing" => JsSuccess(jsValue.as[UserTyping])

--- a/src/test/scala/TestJsonMessages.scala
+++ b/src/test/scala/TestJsonMessages.scala
@@ -1,6 +1,6 @@
 import org.scalatest.FunSuite
 import play.api.libs.json.Json
-import slack.models.{MessageSubtypes, SlackEvent}
+import slack.models.{MessageChanged, MessageSubtypes, SlackEvent}
 
 /**
  * Created by ptx on 9/5/15.
@@ -132,6 +132,35 @@ class TestJsonMessages extends FunSuite {
         |  "subtype":"pizza_box"
         |}""".stripMargin)
     val ev = json.as[MessageSubtypes.UnhandledSubtype]
+  }
+
+  test("message_changed event parsed") {
+    val json = Json.parse(
+      """{
+        |  "type":"message",
+        |  "message":{
+        |    "type":"message",
+        |    "user":"U0W6K3Y6T",
+        |    "text":"Hi",
+        |    "edited":{
+        |      "user":"U0W6K3Y6T",
+        |      "ts":"1461159087.000000"
+        |    },
+        |    "ts":"1461159085.000005"
+        |  },
+        |  "subtype":"message_changed",
+        |  "hidden":true,
+        |  "channel":"G1225QJGJ",
+        |  "previous_message":{
+        |    "type":"message",
+        |    "user":"U0W6K3Y6T",
+        |    "text":"Hii",
+        |    "ts":"1461159085.000005"
+        |  },
+        |  "event_ts":"1461159087.697321",
+        |  "ts":"1461159087.000006"
+        |}""".stripMargin)
+    val ev = json.as[MessageChanged]
   }
 
 }


### PR DESCRIPTION
Currently `message_changed` event, treated as `MessageWithSubtype`. But this event doesn't contain `user` element, and the parsing fails as a result.