### PR TITLE
Adding a dependency override to use spray 1.3.3 for proxy stuff

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -83,6 +83,7 @@ object SlackScalaClient extends Build {
       .settings ( buildSettings : _* )
       .settings ( resolvers ++= Seq(typesafeRepo) )
       .settings ( libraryDependencies ++= Dependencies.allDependencies )
+      .settings ( dependencyOverrides += "io.spray" %% "spray-can" % Dependencies.sprayVersion)
       .settings ( scalacOptions ++= Seq("-unchecked", "-deprecation", "-Xlint", "-Xfatal-warnings", "-feature") )
 
 }


### PR DESCRIPTION
Spray 1.3.3 has a commit in it honoring the HTTP proxy settings, in particular the ones you can use with the JVM: `-Dhttp.proxyHost=www.proxy.com -Dhttp.proxyPort=8088`

I need this where I have to deploy the application. I'm going to verify that it runs with a jit pack of mine and I'll comment that the dependency override worked.