### PR TITLE
Markdown in Attachments

### DIFF
--- a/src/main/scala/slack/models/Attachment.scala
+++ b/src/main/scala/slack/models/Attachment.scala
@@ -14,7 +14,8 @@ case class Attachment (
   fields: Seq[AttachmentField] = Seq.empty,
   image_url: Option[String] = None,
   thumb_url: Option[String] = None,
-  actions: Seq[ActionField] = Seq.empty
+  actions: Seq[ActionField] = Seq.empty,
+  mrkdwn_in: Seq[String] = Seq.empty
 )
 
 case class AttachmentField(title: String, value: String, short: Boolean)


### PR DESCRIPTION
Markdown support is added to Attachments.
Ref: https://api.slack.com/docs/message-formatting
