### PR TITLE
Support for 'apps_installed' event

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -5,7 +5,7 @@ import sbtrelease._
 
 object BuildSettings {
   val buildOrganization = "com.github.gilbertw1"
-  val buildVersion      = "0.2.0"
+  val buildVersion      = "0.2.1"
   val buildScalaVersion = "2.12.1"
   val buildCrossScalaVersions = Seq("2.11.8", "2.12.1")
 

--- a/src/main/scala/slack/models/Events.scala
+++ b/src/main/scala/slack/models/Events.scala
@@ -380,3 +380,8 @@ case class AppsUninstalled(
   app_id: String,
   event_ts: String
 ) extends SlackEvent
+
+case class AppsInstalled(
+                        app: App,
+                        event_ts: String
+                      ) extends SlackEvent

--- a/src/main/scala/slack/models/package.scala
+++ b/src/main/scala/slack/models/package.scala
@@ -117,6 +117,7 @@ package object models {
   implicit val reconnectUrlFmt = Json.format[ReconnectUrl]
   implicit val appsChangedFmt = Json.format[AppsChanged]
   implicit val appsUninstalledFmt = Json.format[AppsUninstalled]
+  implicit val appsInstalledFmt = Json.format[AppsInstalled]
 
   // Message sub-types
   import MessageSubtypes._
@@ -213,6 +214,7 @@ package object models {
         case e: ReconnectUrl => Json.toJson(e)
         case e: AppsChanged => Json.toJson(e)
         case e: AppsUninstalled => Json.toJson(e)
+        case e: AppsInstalled => Json.toJson(e)
       }
     }
   }
@@ -316,6 +318,7 @@ package object models {
           case "reconnect_url" => JsSuccess(jsValue.as[ReconnectUrl])
           case "apps_changed" => JsSuccess(jsValue.as[AppsChanged])
           case "apps_uninstalled" => JsSuccess(jsValue.as[AppsUninstalled])
+          case "apps_installed" => JsSuccess(jsValue.as[AppsInstalled])
           case t: String => JsError(JsonValidationError("Invalid type property: {}", t))
         }
       } else if ((jsValue \ "reply_to").asOpt[Long].isDefined) {


### PR DESCRIPTION
The 'apps_installed' event support was missing. This PR add it to the other supported events and prevents exceptions while using this lib in a Slack App