### PR TITLE
Changed uploadFile to use Either, instead of File/Option[String], I b…

### DIFF
--- a/src/main/scala/slack/api/BlockingSlackApiClient.scala
+++ b/src/main/scala/slack/api/BlockingSlackApiClient.scala
@@ -150,9 +150,8 @@ class BlockingSlackApiClient(token: String, duration: FiniteDuration = 5.seconds
   }
 
   def uploadFile(file: File)(implicit system: ActorSystem): SlackFile = {
-    resolve(client.uploadFile(file))
+    resolve(client.uploadFile(Left(file)))
   }
-
 
   /***************************/
   /****  Group Endpoints  ****/

--- a/src/main/scala/slack/api/SlackApiClient.scala
+++ b/src/main/scala/slack/api/SlackApiClient.scala
@@ -270,18 +270,24 @@ class SlackApiClient(token: String) {
     res.map(_.as[FilesResponse])(system.dispatcher)
   }
 
-  def uploadFile(file: File, content: Option[String] = None, filetype: Option[String] = None, filename: Option[String] = None,
-      title: Option[String] = None, initialComment: Option[String] = None, channels: Option[Seq[String]] = None)(implicit system: ActorSystem): Future[SlackFile] = {
-    val params = Seq (
-      "content" -> content,
+  def uploadFile(content: Either[File, String], filetype: Option[String] = None, filename: Option[String] = None,
+    title: Option[String] = None, initialComment: Option[String] = None, channels: Option[Seq[String]] = None)(implicit system: ActorSystem): Future[SlackFile] = {
+    val params = Seq(
       "filetype" -> filetype,
       "filename" -> filename,
       "title" -> title,
       "initial_comment" -> initialComment,
       "channels" -> channels.map(_.mkString(","))
     )
-    val request = addSegment(apiBaseWithTokenRequest, "files.upload").withEntity(createEntity(file)).withMethod(method = HttpMethods.POST)
-    val res = makeApiRequest(addQueryParams(request, cleanParams(params)))
+
+    val res = content match {
+      case Right(str) =>
+        val request = addSegment(apiBaseWithTokenRequest, "files.upload").withMethod(method = HttpMethods.POST)
+        makeApiRequest(addQueryParams(request, cleanParams(params ++ Seq("content" -> str))))
+      case Left(file) =>
+        val request = addSegment(apiBaseWithTokenRequest, "files.upload").withEntity(createEntity(file)).withMethod(method = HttpMethods.POST)
+        makeApiRequest(addQueryParams(request, cleanParams(params)))
+    }
     extract[SlackFile](res, "file")
   }
 


### PR DESCRIPTION
…elieve this is closer to the api intent

It's a breaking change, but a very easy one to accommodate to,

Simply change 

client.uploadFile(file)  to  client.uploadFile(Left(file))

or

client.uploadFile(null, Some("long message")) to client.uploadFile(Right("long message"))

***Note that without my change you can't actually pass in a null file. 

