### PR TITLE
Upload bytes merge

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -5,7 +5,7 @@ import sbtrelease._
 
 object BuildSettings {
   val buildOrganization = "com.github.gilbertw1"
-  val buildVersion      = "0.2.1"
+  val buildVersion      = "0.2.2-zamblauskas-1"
   val buildScalaVersion = "2.12.1"
   val buildCrossScalaVersions = Seq("2.11.8", "2.12.1")
 
@@ -52,13 +52,13 @@ object Resolvers {
 }
 
 object Dependencies {
-  val akkaVersion = "2.4.14"
+  val akkaVersion = "2.4.19"
 
   val akkaActor = "com.typesafe.akka" %% "akka-actor" % akkaVersion
-  val akkaHttp = "com.typesafe.akka" %% "akka-http-core" % "10.0.0"
+  val akkaHttp = "com.typesafe.akka" %% "akka-http-core" % "10.0.10"
 
-  val scalaAsync = "org.scala-lang.modules" %% "scala-async" % "0.9.6"
-  val playJson = "com.typesafe.play" %% "play-json" % "2.6.0-M1"
+  val scalaAsync = "org.scala-lang.modules" %% "scala-async" % "0.9.7"
+  val playJson = "com.typesafe.play" %% "play-json" % "2.6.3"
 
   val scalatest = "org.scalatest" %% "scalatest" % "3.0.0" % "test"
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -5,7 +5,7 @@ import sbtrelease._
 
 object BuildSettings {
   val buildOrganization = "com.github.gilbertw1"
-  val buildVersion      = "0.2.2-zamblauskas-1"
+  val buildVersion      = "0.2.2"
   val buildScalaVersion = "2.12.1"
   val buildCrossScalaVersions = Seq("2.11.8", "2.12.1")
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.16


### PR DESCRIPTION
Added a new method `uploadFileBytes` which is identical to `uploadFile` but takes `Array[Byte]` instead of a `File`.  
This method is useful when you want to upload dynamically generated content (e.g. image) without writing it to actual OS backed file.

Along the way bumped dependencies and added explicit SBT version, optimized imports.