### PR TITLE
Thread support api client

### DIFF
--- a/src/main/scala/slack/api/BlockingSlackApiClient.scala
+++ b/src/main/scala/slack/api/BlockingSlackApiClient.scala
@@ -112,8 +112,9 @@ class BlockingSlackApiClient(token: String, duration: FiniteDuration = 5.seconds
   def postChatMessage(channelId: String, text: String, username: Option[String] = None, asUser: Option[Boolean] = None,
       parse: Option[String] = None, linkNames: Option[String] = None, attachments: Option[Seq[Attachment]] = None,
       unfurlLinks: Option[Boolean] = None, unfurlMedia: Option[Boolean] = None, iconUrl: Option[String] = None,
-      iconEmoji: Option[String] = None, replaceOriginal: Option[Boolean]= None, deleteOriginal: Option[Boolean] = None)(implicit system: ActorSystem): String = {
-    resolve(client.postChatMessage(channelId, text, username, asUser, parse, linkNames, attachments, unfurlLinks, unfurlMedia, iconUrl, iconEmoji, replaceOriginal, deleteOriginal))
+      iconEmoji: Option[String] = None, replaceOriginal: Option[Boolean]= None, deleteOriginal: Option[Boolean] = None,
+      threadTs: Option[String] = None)(implicit system: ActorSystem): String = {
+    resolve(client.postChatMessage(channelId, text, username, asUser, parse, linkNames, attachments, unfurlLinks, unfurlMedia, iconUrl, iconEmoji, replaceOriginal, deleteOriginal, threadTs))
   }
 
   def updateChatMessage(channelId: String, ts: String, text: String)(implicit system: ActorSystem): UpdateResponse = {

--- a/src/main/scala/slack/api/BlockingSlackApiClient.scala
+++ b/src/main/scala/slack/api/BlockingSlackApiClient.scala
@@ -112,8 +112,8 @@ class BlockingSlackApiClient(token: String, duration: FiniteDuration = 5.seconds
   def postChatMessage(channelId: String, text: String, username: Option[String] = None, asUser: Option[Boolean] = None,
       parse: Option[String] = None, linkNames: Option[String] = None, attachments: Option[Seq[Attachment]] = None,
       unfurlLinks: Option[Boolean] = None, unfurlMedia: Option[Boolean] = None, iconUrl: Option[String] = None,
-      iconEmoji: Option[String] = None)(implicit system: ActorSystem): String = {
-    resolve(client.postChatMessage(channelId, text, username, asUser, parse, linkNames, attachments, unfurlLinks, unfurlMedia, iconUrl, iconEmoji))
+      iconEmoji: Option[String] = None, replaceOriginal: Option[Boolean]= None, deleteOriginal: Option[Boolean] = None)(implicit system: ActorSystem): String = {
+    resolve(client.postChatMessage(channelId, text, username, asUser, parse, linkNames, attachments, unfurlLinks, unfurlMedia, iconUrl, iconEmoji, replaceOriginal, deleteOriginal))
   }
 
   def updateChatMessage(channelId: String, ts: String, text: String)(implicit system: ActorSystem): UpdateResponse = {

--- a/src/main/scala/slack/api/SlackApiClient.scala
+++ b/src/main/scala/slack/api/SlackApiClient.scala
@@ -215,7 +215,7 @@ class SlackApiClient(token: String) {
       parse: Option[String] = None, linkNames: Option[String] = None, attachments: Option[Seq[Attachment]] = None,
       unfurlLinks: Option[Boolean] = None, unfurlMedia: Option[Boolean] = None, iconUrl: Option[String] = None,
       iconEmoji: Option[String] = None, replaceOriginal: Option[Boolean]= None,
-      deleteOriginal: Option[Boolean] = None)(implicit system: ActorSystem): Future[String] = {
+      deleteOriginal: Option[Boolean] = None, threadTs: Option[String] = None)(implicit system: ActorSystem): Future[String] = {
     val res = makeApiMethodRequest (
       "chat.postMessage",
       "channel" -> channelId,
@@ -230,7 +230,8 @@ class SlackApiClient(token: String) {
       "icon_url" -> iconUrl,
       "icon_emoji" -> iconEmoji,
       "replace_original" -> replaceOriginal,
-      "delete_original" -> deleteOriginal)
+      "delete_original" -> deleteOriginal,
+      "thread_ts" -> threadTs)
     extract[String](res, "ts")
   }
 


### PR DESCRIPTION
Just added `thread_ts` to `chat.postMessage`.
Currently available at https://jitpack.io/#yewton/slack-scala-client_2.12/jitpack-SNAPSHOT