### PR TITLE
Added missing dnd_updated_user event

### DIFF
--- a/src/main/scala/slack/models/Events.scala
+++ b/src/main/scala/slack/models/Events.scala
@@ -401,3 +401,15 @@ case class DesktopNotification(
   is_shared: Boolean,
   event_ts: String
 ) extends SlackEvent
+
+case class DndUpdatedUser(
+ `type`: String,
+ user: String,
+ dnd_status: DndStatus,
+ event_ts: String
+) extends SlackEvent
+
+case class DndStatus(dnd_enabled: Boolean,
+ next_dnd_start_ts: Long,
+ next_dnd_end_ts: Long
+)

--- a/src/main/scala/slack/models/package.scala
+++ b/src/main/scala/slack/models/package.scala
@@ -119,6 +119,8 @@ package object models {
   implicit val appsUninstalledFmt = Json.format[AppsUninstalled]
   implicit val appsInstalledFmt = Json.format[AppsInstalled]
   implicit val desktopNotificationFmt = Json.format[DesktopNotification]
+  implicit val dndStatusFmt = Json.format[DndStatus]
+  implicit val dndUpdateUserFmt = Json.format[DndUpdatedUser]
 
   // Message sub-types
   import MessageSubtypes._
@@ -217,6 +219,7 @@ package object models {
         case e: AppsUninstalled => Json.toJson(e)
         case e: AppsInstalled => Json.toJson(e)
         case e: DesktopNotification => Json.toJson(e)
+        case e: DndUpdatedUser => Json.toJson(e)
       }
     }
   }
@@ -322,6 +325,7 @@ package object models {
           case "apps_uninstalled" => JsSuccess(jsValue.as[AppsUninstalled])
           case "apps_installed" => JsSuccess(jsValue.as[AppsInstalled])
           case "desktop_notification" => JsSuccess(jsValue.as[DesktopNotification])
+          case "dnd_updated_user" => JsSuccess(jsValue.as[DndUpdatedUser])
           case t: String => JsError(JsonValidationError("Invalid type property: {}", t))
         }
       } else if ((jsValue \ "reply_to").asOpt[Long].isDefined) {

--- a/src/test/scala/TestJsonMessages.scala
+++ b/src/test/scala/TestJsonMessages.scala
@@ -1,7 +1,7 @@
 import org.scalatest.FunSuite
 import play.api.libs.json.Json
 import slack.models.MessageSubtypes.FileShareMessage
-import slack.models.{BotMessage, GroupJoined, MessageChanged, MessageSubtypes, MessageWithSubtype, ReactionAdded, ReactionItemFile, ReactionItemFileComment, ReactionItemMessage, ReactionRemoved, SlackEvent, SlackFile}
+import slack.models._
 
 /**
  * Created by ptx on 9/5/15.
@@ -212,5 +212,14 @@ class TestJsonMessages extends FunSuite {
         |"event_ts":"1360782804.083113"}""".stripMargin)
     val ev = json.as[SlackEvent]
     assert(ev.equals(ReactionRemoved("thumbsup", ReactionItemFileComment("F0HS27V1Z", "FC0HS2KBEZ"), "1360782804.083113", "U024BE7LH")))
+  }
+
+  test("user dnd status updated") {
+    val json = Json.parse(
+      """{"type":"dnd_updated_user","user":"U024BE7LH",
+        |"dnd_status":{"dnd_enabled":true,"next_dnd_start_ts":1515016800,"next_dnd_end_ts":1515052800},
+        |"event_ts":"1514991882.000376"}""".stripMargin)
+    val ev = json.as[SlackEvent]
+    assert(ev.equals(DndUpdatedUser("dnd_updated_user", "U024BE7LH", DndStatus(dnd_enabled = true, 1515016800, 1515052800), "1514991882.000376")))
   }
 }


### PR DESCRIPTION
Hey really good library however i kept getting an "Error reading event" for [dnd_updated_user](https://api.slack.com/events/dnd_updated_user) events. I noticed you had already fixed a similar issue for desktop_notification [here](https://github.com/gilbertw1/slack-scala-client/commit/69dc64dd268745db25985cc8f28bc39c2d6bbae2) so i did the same for the dnd_updated_user event. Thanks