### PR TITLE
Adding 'attachments' mapping for BotMessages

### DIFF
--- a/src/main/scala/slack/models/Events.scala
+++ b/src/main/scala/slack/models/Events.scala
@@ -45,7 +45,8 @@ case class BotMessage (
   channel: String,
   text: String,
   bot_id: String,
-  username: Option[String]
+  username: Option[String],
+  attachments: Seq[Attachment]
 ) extends SlackEvent
 
 // TODO: Message Sub-types


### PR DESCRIPTION
Adding mapping for existing payload: "attachments" in (incoming) BotMessages