### PR TITLE
Adding 'item_user' mapping for  ReactionAdded/ReactionRemoved

### DIFF
--- a/src/main/scala/slack/models/Events.scala
+++ b/src/main/scala/slack/models/Events.scala
@@ -89,14 +89,16 @@ case class ReactionAdded (
   reaction: String,
   item: ReactionItem,
   event_ts: String,
-  user: String
+  user: String,
+  item_user: String
 ) extends SlackEvent
 
 case class ReactionRemoved (
   reaction: String,
   item: ReactionItem,
   event_ts: String,
-  user: String
+  user: String,
+  item_user: String
 ) extends SlackEvent
 
 case class UserTyping (

--- a/src/test/scala/TestJsonMessages.scala
+++ b/src/test/scala/TestJsonMessages.scala
@@ -193,7 +193,7 @@ class TestJsonMessages extends FunSuite {
         |"item":{"type":"message","channel":"C0G9QF9GZ","ts":"1360782400.498405"},
         |"event_ts":"1360782804.083113"}""".stripMargin)
     val ev = json.as[SlackEvent]
-    assert(ev.equals(ReactionAdded("thumbsup", ReactionItemMessage("C0G9QF9GZ", "1360782400.498405"), "1360782804.083113", "U024BE7LH")))
+    assert(ev.equals(ReactionAdded("thumbsup", ReactionItemMessage("C0G9QF9GZ", "1360782400.498405"), "1360782804.083113", "U024BE7LH", "U0G9QF9C6")))
   }
 
   test("parse reaction added to file") {
@@ -202,7 +202,7 @@ class TestJsonMessages extends FunSuite {
         |"item":{"type":"file","file":"F0HS27V1Z"},
         |"event_ts":"1360782804.083113"}""".stripMargin)
     val ev = json.as[SlackEvent]
-    assert(ev.equals(ReactionAdded("thumbsup", ReactionItemFile("F0HS27V1Z"), "1360782804.083113", "U024BE7LH")))
+    assert(ev.equals(ReactionAdded("thumbsup", ReactionItemFile("F0HS27V1Z"), "1360782804.083113", "U024BE7LH", "U0G9QF9C6")))
   }
 
   test("parse reaction removed from file comment") {
@@ -211,6 +211,6 @@ class TestJsonMessages extends FunSuite {
         |"item":{"type":"file_comment","file":"F0HS27V1Z","file_comment": "FC0HS2KBEZ"},
         |"event_ts":"1360782804.083113"}""".stripMargin)
     val ev = json.as[SlackEvent]
-    assert(ev.equals(ReactionRemoved("thumbsup", ReactionItemFileComment("F0HS27V1Z", "FC0HS2KBEZ"), "1360782804.083113", "U024BE7LH")))
+    assert(ev.equals(ReactionRemoved("thumbsup", ReactionItemFileComment("F0HS27V1Z", "FC0HS2KBEZ"), "1360782804.083113", "U024BE7LH", "U0G9QF9C6")))
   }
 }


### PR DESCRIPTION
Adding mapping for existing payload: 'item_user' in ReactionAdded/ReactionRemoved