### PR TITLE
use sealed trait for ReactionItems

### DIFF
--- a/src/main/scala/slack/models/ReactionItem.scala
+++ b/src/main/scala/slack/models/ReactionItem.scala
@@ -1,6 +1,6 @@
 package slack.models
 
-trait ReactionItem
+sealed trait ReactionItem
 
 case class ReactionItemMessage(channel: String, ts: String) extends ReactionItem
 


### PR DESCRIPTION
Hey,

is there any reason why the ReactionItems trait is not sealed? If not I suggest it to be sealed (I need this for my use cases so that the compiler can reason about it :-)) 

What do you think?

Kind regards