### PR TITLE
lightbend config minor change

### DIFF
--- a/src/main/scala/slack/rtm/WebSocketClientActor.scala
+++ b/src/main/scala/slack/rtm/WebSocketClientActor.scala
@@ -14,7 +14,7 @@ import com.typesafe.config.ConfigFactory
 import slack.rtm.WebSocketClientActor._
 
 import scala.concurrent.Future
-import scala.util.{Failure, Success, Try}
+import scala.util.{Failure, Success}
 
 private[rtm] object WebSocketClientActor {
   case class SendWSMessage(message: Message)
@@ -30,9 +30,7 @@ private[rtm] object WebSocketClientActor {
   case object WebSocketDisconnected
 
   private[this] val config   = ConfigFactory.load()
-  private[this] val useProxy: Boolean = Try(config.getString("slack-scala-client.http.useproxy"))
-    .map(_.toBoolean)
-    .recover{case _:Exception => false}.getOrElse(false)
+  private[this] val useProxy: Boolean = config.getBoolean("slack-scala-client.http.useproxy")
 
   private[WebSocketClientActor] val maybeSettings: Option[ClientConnectionSettings] = if (useProxy) {
     val proxyHost = config.getString("slack-scala-client.http.proxyHost")


### PR DESCRIPTION
Same as [this](https://github.com/slack-scala-client/slack-scala-client/pull/202) but for `WebSocketClientActor`